### PR TITLE
修正 llvm-link 示例命令

### DIFF
--- a/pre/llvm_tool_chain.md
+++ b/pre/llvm_tool_chain.md
@@ -104,7 +104,7 @@ $ clang -emit-llvm -S libsysy.c -o lib.ll
 $ clang -emit-llvm -S main.c -o main.ll
 
 # 2. 使用 llvm-link 将两个文件链接，生成新的 IR 文件
-$ llvm-link main.ll lib.ll  -o out.ll
+$ llvm-link main.ll lib.ll -S -o out.ll
 
 # 3. 用 lli 解释运行
 $ lli out.ll


### PR DESCRIPTION
原来的 `llvm-link` 示例命令生成的 `out.ll` 并不是文本格式的 LLVM IR 而是二进制的 `.bc` 格式，需补充一个 `-S` 选项使得链接后生成的 IR 仍为人类可读的文本格式。

如不加 `-S` 选项，则输出文件名应为 `out.bc` 而不是 `out.ll` 以减少误导。

---
引用 [llvm-link 命令行手册](https://llvm.org/docs/CommandGuide/llvm-link.html) ：
> **-S**
> Write output in LLVM intermediate language (instead of bitcode).